### PR TITLE
docs: update default value for obfuscation in minify configuration

### DIFF
--- a/config/minify.php
+++ b/config/minify.php
@@ -80,7 +80,7 @@ return [
     | This option will obfuscate the javascript code. This may cause an error
     | if the code is not written properly. Please use with caution!
     |
-    | Default: false
+    | Default: true
     |
     */
     'obfuscate' => env('MINIFY_OBFUSCATE', true),


### PR DESCRIPTION
Fixed the config comment to avoid confusion over the default value.