### PR TITLE
feat: skip minify for LD+JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,26 @@ Use this option if Minify for Laravel makes your javascript or css not working p
 ```
 Caution: this option is experimental. If the code still not working properly, you can disable this option and add semicolon manually to your Javascript or CSS code.
 
+### Skip LD+JSON Script Minification
+You can configure Minify for Laravel to automatically skip minification of `<script type="application/ld+json">` tags by setting `skip_ld_json` to `true` in the `config/minify.php` file. This is enabled by default to preserve structured data for SEO purposes. For example:
+
+```php
+"skip_ld_json" => env("MINIFY_SKIP_LD_JSON", true),
+```
+
+When enabled, scripts like this will not be minified:
+
+```html
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "My Company",
+  "url": "https://example.com"
+}
+</script>
+```
+
 ### Skip Minify on Blade
 You can skip minify on blade by using attribute `ignore--minify` inside script or style tag. For example:
 

--- a/config/minify.php
+++ b/config/minify.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Laravel Minify.
  *
@@ -118,6 +119,20 @@ return [
     |
     */
     'obfuscate' => env('MINIFY_OBFUSCATE', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Skip LD+JSON Script Minification
+    |--------------------------------------------------------------------------
+    |
+    | This option will skip minification of <script type="application/ld+json">
+    | tags. LD+JSON scripts contain structured data that should remain readable
+    | and unminified for SEO purposes.
+    |
+    | Default: true
+    |
+    */
+    'skip_ld_json' => env('MINIFY_SKIP_LD_JSON', true),
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Middleware/MinifyJavascript.php
+++ b/src/Middleware/MinifyJavascript.php
@@ -14,8 +14,14 @@ class MinifyJavascript extends Minifier
         static::$allowInsertSemicolon = (bool) config('minify.insert_semicolon.js', false);
         $javascript = new Javascript();
         $obfuscate = (bool) config('minify.obfuscate', false);
+        $skipLdJson = (bool) config('minify.skip_ld_json', true);
 
         foreach ($this->getByTag('script') as $el) {
+            // Skip minification for LD+JSON scripts if option is enabled
+            if ($skipLdJson && $this->isLdJsonScript($el)) {
+                continue;
+            }
+
             $value = $javascript->replace($el->nodeValue, static::$allowInsertSemicolon);
             if ($obfuscate) {
                 $value = $javascript->obfuscate($value);
@@ -25,5 +31,18 @@ class MinifyJavascript extends Minifier
         }
 
         return static::$dom->saveHtml();
+    }
+
+    /**
+     * Check if the script element is an LD+JSON script.
+     *
+     * @param \DOMElement $el
+     *
+     * @return bool
+     */
+    protected function isLdJsonScript($el): bool
+    {
+        return $el->hasAttribute('type') &&
+               strtolower($el->getAttribute('type')) === 'application/ld+json';
     }
 }


### PR DESCRIPTION
**Problem**

Currently, Laravel Minify processes all <script> tags including <script type="application/ld+json"> tags. LD+JSON scripts contain structured data that should remain readable and unminified for SEO purposes and search engine crawlers. Minifying these scripts can break the structured data format and negatively impact SEO.

**Solution**
This PR adds a new configuration option skip_ld_json that allows users to automatically skip minification of <script type="application/ld+json"> tags while still minifying regular JavaScript code.

**Changes Made**

- Configuration
Added skip_ld_json option to config/minify.php (default: true)
Added MINIFY_SKIP_LD_JSON environment variable support
- Core Logic
Modified MinifyJavascript middleware to check script type before minification
Added isLdJsonScript() method for case-insensitive detection of LD+JSON scripts
Scripts with type="application/ld+json" are now skipped when option is enabled